### PR TITLE
Add limit functionality in slack tables. Closes #39

### DIFF
--- a/slack/table_slack_emoji.go
+++ b/slack/table_slack_emoji.go
@@ -40,6 +40,11 @@ func listEmojis(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData)
 	}
 	for name, url := range emojis {
 		d.StreamListItem(ctx, slackEmoji{Name: name, URL: url})
+
+		// Context may get cancelled due to manual cancellation or if the limit has been reached
+		if d.QueryStatus.RowsRemaining(ctx) == 0 {
+			return nil, nil
+		}
 	}
 	return nil, nil
 }

--- a/slack/table_slack_group.go
+++ b/slack/table_slack_group.go
@@ -52,6 +52,11 @@ func listGroups(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData)
 	}
 	for _, group := range groups {
 		d.StreamListItem(ctx, group)
+
+		// Context may get cancelled due to manual cancellation or if the limit has been reached
+		if d.QueryStatus.RowsRemaining(ctx) == 0 {
+			return nil, nil
+		}
 	}
 	return nil, nil
 }

--- a/slack/table_slack_search.go
+++ b/slack/table_slack_search.go
@@ -44,14 +44,45 @@ func listSearches(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 	quals := d.KeyColumnQuals
 	q := quals["query"].GetStringValue()
 	params := slack.NewSearchParameters()
-	msgs, _, err := api.SearchContext(ctx, q, params)
-	if err != nil {
-		plugin.Logger(ctx).Error("slack_search.listSearches", "query_error", err)
-		return nil, err
+	params.Count = 1000
+	pagesLeft := true
+
+	// Reduce the basic request limit down if the user has only requested a small number of rows
+	limit := d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		if *limit < int64(params.Count) {
+			if *limit < 1 {
+				params.Count = 1
+			} else {
+				params.Count = int(*limit)
+			}
+		}
 	}
-	for _, msg := range msgs.Matches {
-		d.StreamListItem(ctx, msg)
+
+	for pagesLeft {
+		msgs, _, err := api.SearchContext(ctx, q, params)
+		if err != nil {
+			plugin.Logger(ctx).Error("slack_search.listSearches", "query_error", err)
+			return nil, err
+		}
+
+		for _, msg := range msgs.Matches {
+			d.StreamListItem(ctx, msg)
+
+			// Context may get cancelled due to manual cancellation or if the limit has been reached
+			if d.QueryStatus.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+
+		if msgs.Paging.Pages != params.Page {
+			pagesLeft = true
+			params.Page = params.Page + 1
+		} else {
+			pagesLeft = false
+		}
 	}
+
 	return nil, nil
 }
 

--- a/slack/table_slack_user.go
+++ b/slack/table_slack_user.go
@@ -97,6 +97,11 @@ func listUsers(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) 
 	}
 	for _, user := range users {
 		d.StreamListItem(ctx, user)
+
+		// Context may get cancelled due to manual cancellation or if the limit has been reached
+		if d.QueryStatus.RowsRemaining(ctx) == 0 {
+			return nil, nil
+		}
 	}
 	return nil, nil
 }


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select id, name from slack_conversation limit 5
+-----------+------------------+
| id        | name             |
+-----------+------------------+
| C7GP3BRKR | ihsm             |
| C5LGHFGRW | nasdaq           |
| CSR5NSYTA | leave-timetastic |
| C1USB84T0 | dev              |
| C6NQ2RQV8 | cdn              |
+-----------+------------------+


> select * from slack_emoji limit 5
+---------------------+---------------------------------------------------------------------------------+-----------------------------+
| name                | url                                                                             | _ctx                        |
+---------------------+---------------------------------------------------------------------------------+-----------------------------+
| eating_cookie       | https://emoji.slack-edge.com/T02GC4A7C/eating_cookie/2e9f6eb66eb63f72.gif       | {"connection_name":"slack"} |
| squirrel            | https://emoji.slack-edge.com/T02GC4A7C/squirrel/465f40c0e0.png                  | {"connection_name":"slack"} |
| turbot-harry-potter | https://emoji.slack-edge.com/T02GC4A7C/turbot-harry-potter/b7055f5c2db38e4c.png | {"connection_name":"slack"} |
| dansgame            | https://emoji.slack-edge.com/T02GC4A7C/dansgame/b09798273bd61c6a.png            | {"connection_name":"slack"} |
| hurtrealbad         | https://emoji.slack-edge.com/T02GC4A7C/hurtrealbad/b9c3d648e6.png               | {"connection_name":"slack"} |
+---------------------+---------------------------------------------------------------------------------+-----------------------------+

> select id, team_id from slack_group limit 5
+-------------+-----------+
| id          | team_id   |
+-------------+-----------+
| S011GUAEZNU | T02GC4A7C |
| S0133MP856G | T02GC4A7C |

> select
  user_name,
  timestamp,
  channel ->> 'name' as channel,
  text
from
  slack_search
where
  query = 'in:#steampipe from:nathan urgent after:3/12/2021' limit 3;
+-----------+---------------------------+-----------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
| user_name | timestamp                 | channel   | text                                                                                                                                                            
+-----------+---------------------------+-----------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
| nathan    | 2021-08-06T07:57:09+05:30 | steampipe | <@U4U7LJ8DU> Can we please create a gradual / non-urgent "chore" to update the README files for all plugins? We need to ensure they are on the latest format, bu
| nathan    | 2021-06-22T05:00:53+05:30 | steampipe | Heads up that I've made the WIP Stripe plugin public on GitHub - <https://github.com/turbot/steampipe-plugin-stripe|https://github.com/turbot/steampipe-plugin-s
|           |                           |           |                                                                                                                                                                 
|           |                           |           | <@U2ENB3HLP> not urgent, but could you please publish the appropriate graphics when you have a chance?                                                          
| nathan    | 2022-05-24T18:35:16+05:30 | steampipe | <@UGPJTD2SE> <@UFX38LGR0> <@U140DDWSU> are we close to releasing the security hub finding table? Would love to answer this question :slightly_smiling_face:. (No
+-----------+---------------------------+-----------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------


> select id, team_id from slack_user limit 5
+-----------+-----------+
| id        | team_id   |
+-----------+-----------+
| U0GQQJPRP | T02GC4A7C |
| U02GC4A7E | T02GC4A7C |
| U0H0K3AJF | T02GC4A7C |
| USLACKBOT | T02GC4A7C |
| U0GQNQ5M1 | T02GC4A7C |
+-----------+-----------+
| S012W5JA8BF | T02GC4A7C |
| S0161C66X8D | T02GC4A7C |
| S9Y35MTQQ   | T02GC4A7C |
+-------------+-----------+


```
</details>
