### PR TITLE
Update the pagination and the limit logic for the tables Closes #52

### DIFF
--- a/slack/table_slack_access_log.go
+++ b/slack/table_slack_access_log.go
@@ -46,14 +46,10 @@ func listAccessLogs(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateD
 	maxPages := 5
 
 	// Reduce the basic request limit down if the user has only requested a small number of rows
-	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
+		limit := d.QueryContext.Limit
 		if *limit < int64(params.Count) {
-			if *limit < 1 {
-				params.Count = 1
-			} else {
-				params.Count = int(*limit)
-			}
+			params.Count = int(*limit)
 		}
 	}
 

--- a/slack/table_slack_conversation.go
+++ b/slack/table_slack_conversation.go
@@ -74,14 +74,10 @@ func listConversations(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydra
 	opts := &slack.GetConversationsParameters{Limit: 1000, Types: []string{"public_channel", "private_channel", "im", "mpim"}}
 
 	// Reduce the basic request limit down if the user has only requested a small number of rows
-	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
+		limit := d.QueryContext.Limit
 		if *limit < int64(opts.Limit) {
-			if *limit < 1 {
-				opts.Limit = 1
-			} else {
-				opts.Limit = int(*limit)
-			}
+			opts.Limit = int(*limit)
 		}
 	}
 

--- a/slack/table_slack_conversation_member.go
+++ b/slack/table_slack_conversation_member.go
@@ -34,9 +34,13 @@ func listConversationMembers(ctx context.Context, d *plugin.QueryData, _ *plugin
 	conversationID := d.EqualsQuals["conversation_id"].GetStringValue()
 	itemsPerPage := int64(100)
 	// Reduce the basic request limit down if the user has only requested a small number of rows
-	if d.QueryContext.Limit != nil && *d.QueryContext.Limit < itemsPerPage {
-		itemsPerPage = *d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		limit := d.QueryContext.Limit
+		if *limit < itemsPerPage {
+			itemsPerPage = int64(*limit)
+		}
 	}
+	
 	opts := &slack.GetUsersInConversationParameters{ChannelID: conversationID, Cursor: "", Limit: int(itemsPerPage)}
 
 	for {

--- a/slack/table_slack_search.go
+++ b/slack/table_slack_search.go
@@ -48,14 +48,10 @@ func listSearches(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 	pagesLeft := true
 
 	// Reduce the basic request limit down if the user has only requested a small number of rows
-	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
+		limit := d.QueryContext.Limit
 		if *limit < int64(params.Count) {
-			if *limit < 1 {
-				params.Count = 1
-			} else {
-				params.Count = int(*limit)
-			}
+			params.Count = int(*limit)
 		}
 	}
 


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>

```
> select
  user_name,
  timestamp,
  channel ->> 'name' as channel,
  text
from
  slack_search
where
  query = 'in:#steampipe from:nathan urgent after:3/12/2021' limit 5
+-----------+---------------------------+-----------+------------------------------------------------------------------------------------------------------------------------------------------------------>
| user_name | timestamp                 | channel   | text                                                                                                                                                 >
+-----------+---------------------------+-----------+------------------------------------------------------------------------------------------------------------------------------------------------------>
| nathan    | 2023-02-14T20:17:57+05:30 | steampipe | <@U140DDWSU|cody> &amp; <@UFX38LGR0|ved> hoping you can add this to your list of things we need to do / setup / test ... It falls into the camp of im>
| nathan    | 2022-11-03T23:25:11+05:30 | steampipe | can add for 18, not urgent for 17 IMO                                                                                                                >
| nathan    | 2022-08-30T07:44:01+05:30 | steampipe | CC <@U9RGP4DDF|lalit>                                                                                                                                >
|           |                           |           |                                                                                                                                                      >
|           |                           |           | I think we're going to need an urgent AWS plugin patch / fix.                                                                                        >
| nathan    | 2023-02-22T21:09:47+05:30 | steampipe | <@U140DDWSU|cody> we do need to update to the new naming at some point ... but as <@U6KS2HUQY|kai> says, not urgent.                                 >
| nathan    | 2022-11-18T19:16:09+05:30 | steampipe | Spoken with <@UFMDH7W5C|john> ... we think we should do an urgent patch to remove the dynamic CRD functionality.                                     >
|           |                           |           |                                                                                                                                                      >
|           |                           |           | That will be smoothest for users etc who have already upgraded.                                                                                      >
|           |                           |           |                                                                                                                                                      >
|           |                           |           | <@U140DDWSU|cody> and <@U01M7AED4UV> let's please action this ASAP.                                                                                  >
+-----------+---------------------------+-----------+------------------------------------------------------------------------------------------------------------------------------------------------------>

> select
  user_name,
  timestamp,
  channel ->> 'name' as channel,
  text
from
  slack_search
where
  query = 'in:#steampipe from:nathan urgent after:3/12/2021';
+-----------+---------------------------+-----------+------------------------------------------------------------------------------------------------------------------------------------------------------>
| user_name | timestamp                 | channel   | text                                                                                                                                                 >
+-----------+---------------------------+-----------+------------------------------------------------------------------------------------------------------------------------------------------------------>
| nathan    | 2022-03-31T00:30:49+05:30 | steampipe | <@UFX38LGR0|ved> I've pushed changes to the hackernews plugin to upgrade it to the latest SDK version. Can you please package and release at some poi>
| nathan    | 2023-02-22T21:09:47+05:30 | steampipe | <@U140DDWSU|cody> we do need to update to the new naming at some point ... but as <@U6KS2HUQY|kai> says, not urgent.                                 >
| nathan    | 2021-11-09T20:18:28+05:30 | steampipe | (BTW - none of this is urgent from my point of view)                                                                                                 >
| nathan    | 2022-08-30T07:44:01+05:30 | steampipe | CC <@U9RGP4DDF|lalit>                                                                                                                                >
|           |                           |           |                                                                                                                                                      >
|           |                           |           | I think we're going to need an urgent AWS plugin patch / fix.                                                                                        >
| nathan    | 2021-06-14T20:43:35+05:30 | steampipe | If we had a controls tab separate from benchmarks, then like queries, we'd just link the benchmark to the control.                                   >
|           |                           |           |                                                                                                                                                      >
|           |                           |           | I don't think we should have separate control/benchmark tabs though, so that means a control is normally shown in the context of a benchmark.        >
|           |                           |           |                                                                                                                                                      >
|           |                           |           | But ... as you say ... who knows how many?                                                                                                           >
|           |                           |           |                                                                                                                                                      >
|           |                           |           | So - #1 is a reasonable approach, which is to just show it standalone in the mod it is in with the left nav collapsed.                               >
|           |                           |           |                                                                                                                                                      >
|           |                           |           | In future (not urgent) it would be great if a control could show the list of benchmarks it's included in. That would make the control page feel more >
| nathan    | 2022-11-03T23:25:11+05:30 | steampipe | can add for 18, not urgent for 17 IMO                                                                                                                >
| nathan    | 2022-11-02T02:02:27+05:30 | steampipe | The Nov 2022 OpenSSL vulnerability called Spooky SSL (`CVE-2022-3602) notes:                                                                         >
|           |                           |           | • High vulnerability (downgraded from Critical)                                                                                                      >
|           |                           |           | • Only affects servers if running with a malicious malformed certificate.                                                                            >
|           |                           |           |                                                                                                                                                      >
|           |                           |           | <https://github.com/NCSC-NL/OpenSSL-2022>                                                                                                            >
|           |                           |           |                                                                                                                                                      >
|           |                           |           | This now does not apply to Steampipe immediately, so we have no urgent action required. We should of course continue to patch our various items as we>
| nathan    | 2021-09-01T23:24:11+05:30 | steampipe | <@U6Q49SJ81|mike> <@U3QRZSXU7|victor> Not urgent, but FYI that latestpipe seems to be crashing for me right now when I try to login via github?      >
| nathan    | 2021-03-15T19:31:42+05:30 | steampipe | Hopefully it affects just the one user. If it's affecting others then obviously we'll need to patch urgently.                                        >
| nathan    | 2022-05-24T18:35:16+05:30 | steampipe | <@UGPJTD2SE|partha> <@UFX38LGR0|ved> <@U140DDWSU|cody> are we close to releasing the security hub finding table? Would love to answer this question :>
| nathan    | 2021-11-12T23:48:25+05:30 | steampipe | which plugins are impacted? how urgent is the fix?                                                                                                   >
| nathan    | 2022-11-02T02:02:42+05:30 | steampipe | The Nov 2022 OpenSSL vulnerability called Spooky SSL (`CVE-2022-3602) notes:                                                                         >

> select * from slack_conversation_member where conversation_id = 'C02GC4A7Q' limit 4
+-----------------+-----------+------------------+-----------------------------+
| conversation_id | member_id | workspace_domain | _ctx                        |
+-----------------+-----------+------------------+-----------------------------+
| C02GC4A7Q       | U0K7FH41G | turbothq         | {"connection_name":"slack"} |
| C02GC4A7Q       | U2ENB3HLP | turbothq         | {"connection_name":"slack"} |
| C02GC4A7Q       | U02GC4A7E | turbothq         | {"connection_name":"slack"} |
| C02GC4A7Q       | U140DDWSU | turbothq         | {"connection_name":"slack"} |
+-----------------+-----------+------------------+-----------------------------+

> select * from slack_conversation_member where conversation_id = 'C02GC4A7Q'
+-----------------+-------------+------------------+-----------------------------+
| conversation_id | member_id   | workspace_domain | _ctx                        |
+-----------------+-------------+------------------+-----------------------------+
| C02GC4A7Q       | U0K7FH41G   | turbothq         | {"connection_name":"slack"} |
| C02GC4A7Q       | U7UDJ7GBV   | turbothq         | {"connection_name":"slack"} |
| C02GC4A7Q       | UB1BZ6QLV   | turbothq         | {"connection_name":"slack"} |
| C02GC4A7Q       | U140DDWSU   | turbothq         | {"connection_name":"slack"} |
| C02GC4A7Q       | UBKA9TFHQ   | turbothq         | {"connection_name":"slack"} |
| C02GC4A7Q       | U9Z7VQEDS   | turbothq         | {"connection_name":"slack"} |
| C02GC4A7Q       | UBZT1D256   | turbothq         | {"connection_name":"slack"} |
| C02GC4A7Q       | UCL646Q0M   | turbothq         | {"connection_name":"slack"} |
| C02GC4A7Q       | U4U7LJ8DU   | turbothq         | {"connection_name":"slack"} |
| C02GC4A7Q       | UH8DQNUVA   | turbothq         | {"connection_name":"slack"} |
| C02GC4A7Q       | U3QRZSXU7   | turbothq         | {"connection_name":"slack"} |
| C02GC4A7Q       | UF8SKP8MD   | turbothq         | {"connection_name":"slack"} |
| C02GC4A7Q       | U6KS2HUQY   | turbothq         | {"connection_name":"slack"} |
| C02GC4A7Q       | UFX38LGR0   | turbothq         | {"connection_name":"slack"} |
| C02GC4A7Q       | UHJPG5XRU   | turbothq         | {"connection_name":"slack"} |
| C02GC4A7Q       | UFX03KCJF   | turbothq         | {"connection_name":"slack"} |
| C02GC4A7Q       | UF8SL4FJB   | turbothq         | {"connection_name":"slack"} |
| C02GC4A7Q       | UF6GBSNAV   | turbothq         | {"connection_name":"slack"} |
| C02GC4A7Q       | UMTJXLNQ3   | turbothq         | {"connection_name":"slack"} |
| C02GC4A7Q       | U0550AZP4B1 | turbothq         | {"connection_name":"slack"} |

> select * from slack_conversation limit 5
+-----------+----------+---------------------------+-----------+-------------+------------+---------------+------------+----------+-------+-----------+---------+---------------+-----------------------+-->
| id        | name     | created                   | creator   | is_archived | is_channel | is_ext_shared | is_general | is_group | is_im | is_member | is_mpim | is_org_shared | is_pending_ext_shared | i>
+-----------+----------+---------------------------+-----------+-------------+------------+---------------+------------+----------+-------+-----------+---------+---------------+-----------------------+-->
| C02GC4A7Q | random   | 2014-08-19T09:33:32+05:30 | U02GC4A7E | false       | true       | false         | false      | false    | false | true      | false   | false         | false                 | f>
| C0GQL9DB7 | e-gineer | 2015-12-17T00:01:51+05:30 | U02GC4A7E | true        | true       | false         | false      | false    | false | false     | false   | false         | false                 | f>
| C02GC4A7N | general  | 2014-08-19T09:33:32+05:30 | U02GC4A7E | false       | true       | false         | true       | false    | false | true      | false   | false         | false                 | f>
| C0GQQFJQM | rgc      | 2015-12-17T00:44:29+05:30 | U02GC4A7E | true        | true       | false         | false      | false    | false | false     | false   | false         | false                 | f>
| C0GQP4WEQ | rit      | 2015-12-17T00:44:33+05:30 | U02GC4A7E | true        | true       | false         | false      | false    | false | false     | false   | false         | false                 | f>
+-----------+----------+---------------------------+-----------+-------------+------------+---------------+------------+----------+-------+-----------+---------+---------------+-----------------------+-->

> select * from slack_conversation
+-------------+--------------------------------------------------------------------------------------------------+---------------------------+-------------+-------------+------------+---------------+------------+----------+-------+-----------+---------+---------------+>
| id          | name                                                                                             | created                   | creator     | is_archived | is_channel | is_ext_shared | is_general | is_group | is_im | is_member | is_mpim | is_org_shared |>
+-------------+--------------------------------------------------------------------------------------------------+---------------------------+-------------+-------------+------------+---------------+------------+----------+-------+-----------+---------+---------------+>
| CDF8S359R   | sentry                                                                                           | 2018-10-16T20:42:45+05:30 | UBLHARBMG   | true        | true       | false         | false      | false    | false | false     | false   | false         |>
| C013FH44Y58 | domains                                                                                          | 2020-05-12T07:38:51+05:30 | UHJPG5XRU   | true        | true       | false         | false      | false    | false | false     | false   | false         |>
| CE05WLQ0L   | usaa-turbot                                                                                      | 2018-11-10T04:22:09+05:30 | U0K7FH41G   | true        | true       | false         | false      | false    | false | false     | false   | false         |>
| C7E3405PW   | dish                                                                                             | 2017-10-05T22:11:14+05:30 | U4DVD69PY   | true        | true       | false         | false      | false    | false | false     | false   | false         |>
| C29GV04QL   | hcm                                                                                              | 2016-09-08T19:37:34+05:30 | U0K7FH41G   | true        | true       | false         | false      | false    | false | false     | false   | false         |>
| CLR7CA924   | cse_os                                                                                           | 2019-07-25T05:34:37+05:30 | U7UDJ7GBV   | false       | true       | false         | false      | false    | false | false     | false   | false         |>
| C5H598YA2   | tableau                                                                                          | 2017-05-22T20:19:37+05:30 | U0K7FH41G   | true        | true       | false         | false      | false    | false | false     | false   | false         |>
| CAJE6K6TU   | thermofisher-turbot                                                                              | 2018-05-04T19:38:00+05:30 | U2ENB3HLP   | true        | true       | false         | false      | false    | false | false     | false   | false         |>
| CH957GTPG   | india-communication                                                                              | 2019-03-23T08:05:12+05:30 | U4U7LJ8DU   | false       | true       | false         | false      | false    | false | true      | false   | false         |>
| CH9QNLH43   | pegboard                                                                                         | 2019-04-05T19:54:47+05:30 | U0K7FH41G   | false       | true       | false         | false      | false    | false | false     | false   | false         |>
| C01AC8JQNHH | steampipe                                                                                        | 2020-09-09T18:54:24+05:30 | U6KS2HUQY   | false       | true       | false         | false      | false    | false | true      | false   | false         |>
| CEPV4TWN9   | test-build-slack-room                                                                            | 2018-12-10T18:39:25+05:30 | UCL646Q0M   | false       | true       | false         | false      | false    | false | true      | false   | false         |>
| CE3456SBH   | deloitte                                                                                         | 2018-11-13T10:07:28+05:30 | UBLHARBMG   | true        | true       | false         | false      | false    | false | false     | false   | false         |>

> select * from slack_user limit 2
+-----------+--------------+------------+--------+--------+---------+-------------------------+-------------------+------------+---------+------------------------------------------------------------------------------------+---------------------------------------------->
| id        | display_name | api_app_id | bot_id | color  | deleted | display_name_normalized | email             | first_name | has_2fa | image_24                                                                           | image_32                                     >
+-----------+--------------+------------+--------+--------+---------+-------------------------+-------------------+------------+---------+------------------------------------------------------------------------------------+---------------------------------------------->
| U02GC4A7E | nathan       | <null>     | <null> | 9f69e7 | false   | nathan                  | nathan@turbot.com | Nathan     | false   | https://avatars.slack-edge.com/2017-03-08/152380110279_d1f270093ca5a41f3d94_24.jpg | https://avatars.slack-edge.com/2017-03-08/152>
| USLACKBOT | Slackbot     | <null>     | <null> | 757575 | false   | Slackbot                | <null>            | slackbot   | false   | https://a.slack-edge.com/80588/img/slackbot_24.png                                 | https://a.slack-edge.com/80588/img/slackbot_3>
+-----------+--------------+------------+--------+--------+---------+-------------------------+-------------------+------------+---------+------------------------------------------------------------------------------------+---------------------------------------------->

> select * from slack_group
+-------------+-----------+---------------+----------------------------+---------------------------------------------------------+------------------------+-------------+---------------------------+---------------------------+---------------------------+-----------+---->
| id          | team_id   | is_user_group | name                       | description                                             | handle                 | is_external | date_create               | date_update               | date_delete               | auto_type | cre>
+-------------+-----------+---------------+----------------------------+---------------------------------------------------------+------------------------+-------------+---------------------------+---------------------------+---------------------------+-----------+---->
| S01BSR6BFA9 | T02GC4A7C | true          | Customer Support Engineers | Group for CS Engineers that deal directly with clients. | cs-engineers           | false       | 2020-10-03T00:12:03+05:30 | 2023-07-21T20:44:42+05:30 | <null>                    | <null>    | UQS>
| S01E3SNSAR0 | T02GC4A7C | true          | UI                         | For messaging all of the UI team members.               | ui-group               | false       | 2020-11-05T21:38:12+05:30 | 2021-03-11T15:06:38+05:30 | <null>                    | <null>    | U6Q>
| S9Y35MTQQ   | T02GC4A7C | true          | Turbot                     | <null>                                                  | turbot                 | false       | 2018-03-30T17:31:02+05:30 | 2018-03-30T17:31:56+05:30 | <null>                    | <null>    | U0K>
| S0161C66X8D | T02GC4A7C | true          | Sales                      | <null>                                                  | sales-group            | false       | 2020-06-26T02:27:02+05:30 | 2023-07-25T00:58:15+05:30 | <null>                    | <null>    | U0K>
| S011GUAEZNU | T02GC4A7C | true          | Expeditors                 | For messaging all of the Expediter team members.        | expeditor-group        | false       | 2020-04-03T21:08:57+05:30 | 2020-09-28T23:30:46+05:30 | 2020-09-28T23:30:46+05:30 | <null>    | UBL>
| S012W5JA8BF | T02GC4A7C | true          | Customer Success           | For messaging all of the Customer Success team members. | customer-success-group | false       | 2020-05-02T02:22:13+05:30 | 2020-09-28T23:31:28+05:30 | <null>                    | <null>    | UBL>
| S018S0QVDML | T02GC4A7C | true          | Sales - Kingfisher Team    | <null>                                                  | sales-kingfisher       | false       | 2020-08-17T16:23:21+05:30 | 2020-12-24T00:29:02+05:30 | 2020-12-24T00:29:02+05:30 | <null>    | U0K>
| S016SJJJEJU | T02GC4A7C | true          | Marketing                  | <null>                                                  | marketing-group        | false       | 2020-06-26T02:27:54+05:30 | 2020-06-26T02:27:54+05:30 | <null>                    | <null>    | U0K>
| S018J0DGNHM | T02GC4A7C | true          | Sales - CDP Team           | <null>                                                  | sales-cdp              | false       | 2020-08-17T16:23:54+05:30 | 2020-12-24T00:29:06+05:30 | 2020-12-24T00:29:06+05:30 | <null>    | U0K>
| S0133MP856G | T02GC4A7C | true          | Core                       | For messaging all of the Core team members.             | core-group             | false       | 2020-05-02T02:17:07+05:30 | 2020-11-05T21:40:38+05:30 | <null>                    | <null>    | UBL>
+-------------+-----------+---------------+----------------------------+---------------------------------------------------------+------------------------+-------------+---------------------------+---------------------------+---------------------------+-----------+---->


```
</details>
