### PR TITLE
Add pagination support for the table slack_user Closes #56

### DIFF
--- a/slack/table_slack_user.go
+++ b/slack/table_slack_user.go
@@ -140,13 +140,13 @@ func getUser(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (i
 	} else if len(email) > 0 {
 		info, err = api.GetUserByEmailContext(ctx, email)
 	} else {
-		plugin.Logger(ctx).Warn("slack_user.getUser", "invalid_quals", "id and email both empty", "quals", quals)
+		plugin.Logger(ctx).Error("slack_user.getUser", "invalid_quals", "id and email both empty", "quals", quals)
 		return nil, nil
 	}
 
 	if err != nil {
 		if err.Error() == "user_not_found" || err.Error() == "users_not_found" {
-			plugin.Logger(ctx).Warn("slack_user.getUser", "not_found_error", err, "quals", quals)
+			plugin.Logger(ctx).Error("slack_user.getUser", "not_found_error", err, "quals", quals)
 			return nil, nil
 		}
 		plugin.Logger(ctx).Error("slack_user.getUser", "query_error", err, "quals", quals)

--- a/slack/table_slack_user.go
+++ b/slack/table_slack_user.go
@@ -91,34 +91,34 @@ func listUsers(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) 
 
 	// Use 200 as default API limit, as recommended in the docs
 	pageLimit := 200
-	limit := int(d.QueryContext.GetLimit())
-
-	if limit < pageLimit {
-		pageLimit = limit
+	if d.QueryContext.Limit != nil {
+		limit := int(*d.QueryContext.Limit)
+		if limit < pageLimit {
+			pageLimit = limit
+		}
 	}
 
 	// Paginate ourselves instead of api.GetUsersContext to respect the query's limit
-	var users []slack.User
-	for (limit == -1 || len(users) < limit) && err == nil {
-		p := api.GetUsersPaginated(slack.GetUsersOptionLimit(pageLimit))
+	p := api.GetUsersPaginated(slack.GetUsersOptionLimit(pageLimit))
+	for {
 		p, err = p.Next(ctx)
-		if err == nil {
-			users = append(users, p.Users...)
+		if p.Done(err) {
+			break
+		}
+		if err != nil {
+			plugin.Logger(ctx).Warn("slack_user.listUsers", "query_error", err)
+			return nil, err
+		}
+		for _, user := range p.Users {
+			d.StreamListItem(ctx, user)
+
+			// Context may get cancelled due to manual cancellation or if the limit has been reached
+			if d.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
 		}
 	}
 
-	if err != nil {
-		plugin.Logger(ctx).Warn("slack_user.listUsers", "query_error", err)
-		return nil, err
-	}
-	for _, user := range users {
-		d.StreamListItem(ctx, user)
-
-		// Context may get cancelled due to manual cancellation or if the limit has been reached
-		if d.RowsRemaining(ctx) == 0 {
-			return nil, nil
-		}
-	}
 	return nil, nil
 }
 

--- a/slack/table_slack_user.go
+++ b/slack/table_slack_user.go
@@ -98,7 +98,7 @@ func listUsers(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) 
 		}
 	}
 
-	// Paginate ourselves instead of api.GetUsersContext to respect the query's limit
+	// Handle pagination manually instead of using api.GetUsersContext to respect the query's limit
 	p := api.GetUsersPaginated(slack.GetUsersOptionLimit(pageLimit))
 	for {
 		p, err = p.Next(ctx)


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>

```
> select * from slack_user
+-------------+-------------------------+-------------+-------------+--------+---------+-------------------------+-----------------------------------------------+------------------------+---------+------------------------------------------------------------------------>
| id          | display_name            | api_app_id  | bot_id      | color  | deleted | display_name_normalized | email                                         | first_name             | has_2fa | image_24                                                               >
+-------------+-------------------------+-------------+-------------+--------+---------+-------------------------+-----------------------------------------------+------------------------+---------+------------------------------------------------------------------------>
| U22JUMATT   | scottbward              | <null>      | <null>      | <null> | true    | scottbward              | scottbward74@gmail.com                        | Scott                  | false   | https://secure.gravatar.com/avatar/1da870b44b8d56f9868b220301622358.jpg>
| U1140SE2J   | jprewitt                | <null>      | <null>      | <null> | true    | jprewitt                | john.prewitt@regeneron.com                    | John                   | false   | https://secure.gravatar.com/avatar/747847baa7c52c6d7d55950f06f57e37.jpg>
| U02GC4A7E   | nathan                  | <null>      | <null>      | 9f69e7 | false   | nathan                  | nathan@turbot.com                             | Nathan                 | false   | https://avatars.slack-edge.com/2017-03-08/152380110279_d1f270093ca5a41f>
| U15L6AYAX   | bpatton                 | <null>      | <null>      | <null> | true    | bpatton                 | brandon.patton@biogen.com                     | Brandon                | false   | https:

> select * from slack_user limit 2
+-----------+--------------+------------+--------+--------+---------+-------------------------+-------------------+------------+---------+------------------------------------------------------------------------------------+---------------------------------------------->
| id        | display_name | api_app_id | bot_id | color  | deleted | display_name_normalized | email             | first_name | has_2fa | image_24                                                                           | image_32                                     >
+-----------+--------------+------------+--------+--------+---------+-------------------------+-------------------+------------+---------+------------------------------------------------------------------------------------+---------------------------------------------->
| U02GC4A7E | nathan       | <null>     | <null> | 9f69e7 | false   | nathan                  | nathan@itrhub.com | Nathan     | false   | https://avatars.slack-edge.com/2017-03-08/152380110279_d1f270093ca5a41f3d94_24.jpg | https://avatars.slack-edge.com/2017-03-08/152>
| USLACKBOT | Slackbot     | <null>     | <null> | 757575 | false   | Slackbot                | <null>            | slackbot   | false   | https://a.slack-edge.com/80588/img/slackbot_24.png                                 | https://a.slack-edge.com/80588/img/slackbot_3>
+-----------+--------------+------------+--------+--------+---------+-------------------------+-------------------+------------+---------+------------------------------------------------------------------------------------+---------------------------------------------->

Time: 1.2s. Rows fetched: 2. Hydrate calls: 2.
```
</details>
